### PR TITLE
Fix garble installation by enabling Go toolchain auto download

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 ### 1、直接运行docker-compose up -d
 ### 2、若需要改端口，则需要修改三个文件,docker-compose.yml中修改rssh的端口(使用cdn上线和wss协议最好修改成443端口),还需要修改const.py中rssh_port和rssh目录下docker-entrypoint.sh中的端口，并确保一致
 ### 3、如果是想备份之前的supershell,则需要将之前项目下volume整个目录移植过去,但是要确保本项目/volume/rssh/cache/data.db不能丢失
+### 4、如果需要指定客户端连接时看到的外部访问地址，请在执行 `docker compose up -d` 前运行 `export EXTERNAL_ADDRESS=47.236.199.36:3232`（或替换为实际地址），也可以在 `.env` 中设置 `EXTERNAL_ADDRESS`，未设置时默认值为 `:3232`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     ports:
       - 3232:3232
     privileged: false
+    environment:
+      - EXTERNAL_ADDRESS=${EXTERNAL_ADDRESS:-:3232}
     volumes:
       - ./volume/rssh:/data
       - ./volume/flask/authorized_keys:/data/authorized_keys

--- a/flask/module/compile.py
+++ b/flask/module/compile.py
@@ -11,6 +11,7 @@ import os
 import time
 
 import re
+import shlex
 
 
 def get_compiled_clients_list():
@@ -173,17 +174,42 @@ def makeClient(key_file, rssh_ip, rssh_port, make_input_dict):
             except Exception as e:
                 current_app.logger.exception(e)
                 return {'stat': 'failed', 'result': 'Rssh Connect Error'}
-            proxy_cmd = '--proxy ' + make_input_dict['address_proxy'] + ':' + make_input_dict['port_proxy'] if make_input_dict['address_proxy'] != '' and make_input_dict['port_proxy'] != '' else ''
-            flow_cmd = '--' + make_input_dict['flow'] if make_input_dict['flow'] != '' and make_input_dict['flow'] != 'ssh' else ''
-            upx = '--upx' if make_input_dict['upx'] else ''
-            garble = '--garble' if make_input_dict['garble'] else ''
             os, arch = make_input_dict['os_arch'].split('/')
+
+            make_cmd_parts = [
+                'link',
+                '--name', make_input_dict['filename'],
+                '--goos', os
+            ]
+
             if (os == 'windows' and arch == 'dll') or (os == 'linux' and arch == 'so'):
-                make_cmd = 'link --name ' + make_input_dict['filename'] + ' --goos ' + os + ' --shared-object -s ' + \
-                           make_input_dict['address'] + ':' + make_input_dict['port'] + ' ' + upx + ' ' + garble + ' ' + proxy_cmd + ' ' + flow_cmd + ' '+ '--process'+' '+make_input_dict['process'] + ' ' + '--log-level' + ' '+ make_input_dict['log_level']
+                make_cmd_parts.append('--shared-object')
             else:
-                make_cmd = 'link --name ' + make_input_dict['filename'] + ' --goos ' + os + ' --goarch ' + arch + ' -s ' + \
-                           make_input_dict['address'] + ':' + make_input_dict['port'] + ' ' + upx + ' ' + garble + ' ' + proxy_cmd + ' ' + flow_cmd +' '+ '--process'+' '+make_input_dict['process'] + ' ' + '--log-level' + ' '+ make_input_dict['log_level']
+                make_cmd_parts.extend(['--goarch', arch])
+
+            make_cmd_parts.extend(['-s', make_input_dict['address'] + ':' + make_input_dict['port']])
+
+            if make_input_dict['upx']:
+                make_cmd_parts.append('--upx')
+
+            if make_input_dict['garble']:
+                make_cmd_parts.append('--garble')
+
+            if make_input_dict['address_proxy'] != '' and make_input_dict['port_proxy'] != '':
+                make_cmd_parts.extend([
+                    '--proxy',
+                    make_input_dict['address_proxy'] + ':' + make_input_dict['port_proxy']
+                ])
+
+            if make_input_dict['flow'] not in ['', 'ssh']:
+                make_cmd_parts.append('--' + make_input_dict['flow'])
+
+            if make_input_dict['process']:
+                make_cmd_parts.extend(['--process', make_input_dict['process']])
+
+            make_cmd_parts.extend(['--log-level', make_input_dict['log_level']])
+
+            make_cmd = ' '.join(shlex.quote(part) for part in make_cmd_parts if part)
             current_app.logger.info('Make client Cmd: ' + str(make_cmd))
             make_result = rssh_target.exec_command(make_cmd)
             if make_result['stat'] == 'success':

--- a/rssh/Dockerfile
+++ b/rssh/Dockerfile
@@ -6,9 +6,10 @@ RUN apt -y --no-install-recommends update && \
     apt -y --no-install-recommends upgrade && \
     apt install -y --no-install-recommends upx-ucl gcc-mingw-w64 && \
     rm -rf /var/cache/apk/* && \
-    go install mvdan.cc/garble@latest
+    GOTOOLCHAIN=auto go install mvdan.cc/garble@latest
 
 ENV PATH="${PATH}:$(go env GOPATH)/bin"
+ENV GOTOOLCHAIN=auto
 
 COPY go.mod go.sum ./
 

--- a/rssh/Dockerfile
+++ b/rssh/Dockerfile
@@ -2,13 +2,19 @@ FROM golang:bullseye
 
 WORKDIR /app
 
+ARG GO_VERSION=1.25.0
+
 RUN apt -y --no-install-recommends update && \
     apt -y --no-install-recommends upgrade && \
-    apt install -y --no-install-recommends upx-ucl gcc-mingw-w64 && \
-    rm -rf /var/cache/apk/* && \
+    apt install -y --no-install-recommends curl upx-ucl gcc-mingw-w64 && \
+    curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tgz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf /tmp/go.tgz && \
+    rm -f /tmp/go.tgz && \
+    rm -rf /var/lib/apt/lists/* && \
     GOTOOLCHAIN=auto go install mvdan.cc/garble@latest
 
-ENV PATH="${PATH}:$(go env GOPATH)/bin"
+ENV PATH="/usr/local/go/bin:${PATH}:$(go env GOPATH)/bin"
 ENV GOTOOLCHAIN=auto
 
 COPY go.mod go.sum ./

--- a/rssh/docker-entrypoint.sh
+++ b/rssh/docker-entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
+set -euo pipefail
+
 cd /app/bin
-if [ -d "/data/tls" -a -f "/data/tls/tls.cert" -a -f "/data/tls/tls.key" ]       
-then
-    exec /app/wait-for-it.sh -t 0 flask:5000 -- ./server --datadir /data --enable-client-downloads  --external_address :3232 --tls --tlscert /data/tls/tls.cert --tlskey /data/tls/tls.key
+
+external_address="${EXTERNAL_ADDRESS:-:3232}"
+
+WAIT_CMD=(/app/wait-for-it.sh -t 0 flask:5000 -- ./server --datadir /data --enable-client-downloads --external_address "${external_address}")
+
+if [ -d "/data/tls" ] && [ -f "/data/tls/tls.cert" ] && [ -f "/data/tls/tls.key" ]; then
+    exec "${WAIT_CMD[@]}" --tls --tlscert /data/tls/tls.cert --tlskey /data/tls/tls.key
 else
-    exec /app/wait-for-it.sh -t 0 flask:5000 -- ./server --datadir /data --enable-client-downloads  --external_address :3232 --tls
+    exec "${WAIT_CMD[@]}" --tls
 fi


### PR DESCRIPTION
## Summary
- allow the rssh Docker image to download a newer Go toolchain when installing garble
- export GOTOOLCHAIN=auto so subsequent go commands reuse the compatible toolchain

## Testing
- ⚠️ `docker build -t supershell-rssh-test .` *(Docker is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3928b8d3c832d998b4e14d5bfb99f